### PR TITLE
fix: parse Azure AD callback url

### DIFF
--- a/src/pages/callback.tsx
+++ b/src/pages/callback.tsx
@@ -1,19 +1,22 @@
-import { parse } from 'query-string';
-import { isEmpty } from 'ramda';
-import { useEffect, useState } from 'react';
-import { useRouter } from 'next/router';
-import { Message } from '@navch-ui/core';
+import { parse } from "query-string";
+import { isEmpty } from "ramda";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/router";
+import { Message } from "@navch-ui/core";
 
-import { Layout } from '@components/Layout';
-import { InteractionResult } from '@components/InteractionResult';
+import { Layout } from "@components/Layout";
+import { InteractionResult } from "@components/InteractionResult";
 
 export default function CallbackScreen() {
   const router = useRouter();
-  const query = router.asPath.includes('#') ? parse(router.asPath.split('#', 2)[1]) : router.query;
+  const url = router.asPath;
+  const query = (url.includes("?") || !url.includes("#"))
+    ? router.query
+    : parse(url.split("#", 2)[1]);
 
   const [params, setParams] = useState<Record<string, string>>();
   useEffect(() => {
-    console.debug('[CallbackScreen] Parsed params:', query);
+    console.debug("[CallbackScreen] Parsed params:", query);
 
     if (isEmpty(query)) return;
     setParams(query as Record<string, string>);


### PR DESCRIPTION
Hi dear code owner,

Not sure what's your previous intention of `parse(router.asPath.split('#', 2)[1])`, it could not handle the callback from Azure AD which has an ending `#`:

```
http://localhost:3000/oauth/callback?code=0.AUIAc8_Jwq5qAkeYRAKtq3I3cdWsGREzz4JHnS7g9NJ2gTdCABQ.AQABAAIAAAD--DLA3VO7QrddgJg7WevrDg11tsHQfYnVRLTa4DRSrTlX8sQB0ZkYJkkNnhyGS7bIlFj-blMT0yGIrbGkBw7Gqh_hl5IcYb3Rni1tTvKSy-kRLXcQdasUrh57DrU_MwbfxJ9kpfxx-8dOZJpLebSTCaVJzHgbjNFo2mwNXOdUTHtTbtSjTOjZsnDFOBcLqE1Jt6Rn37CTtmSLKWajOe2ejcKTYICUwH3-P5Bu9RW-dQNU07G03C59AeticjkP_HUBa3ukV058wgTOuO0wQb4OLlcJQY0BnUXGkueyH8_UyBB0ZD3so2y15MJebSxev_e6XkUUOckOwVfNGof-ue-ThLAODDdR1mWPZxUQcT3CNsM2awNmnJMWeccMTy_8FEUI0kFXCVrsn6buYel9kXvlvexZZdEf71fqD3JhQJ762m6u37F2MnE9_H32D1NKLmYbTxK4Ya5k0jqpCQr2kw0Ft_5MPIvQA3Ce5mxCVccdAfbRRGAvoSlLDAPCnlVWpnukDKq5Ee6kKR1dMMS6l6DQlUX4xjbIjJ9q69A1SU5gexkEpjpKOyEbhgzCI8VEyhJb_obot4IOXtGTNG9LH7w7QgOUzIlbUaUou9CMt5jjCA1r98pjYfXEGN9AGO21EfvQl5jXaB7JRIke_9XbVN0LiFt8eoqu9781wIYpmbNpGlilebpWPDTGNxL4vyfqasEgAA&state=g8lCTscbG6e2SjCIcjWqWvQST-9VZr6Rx9dcIoMxqkw&session_state=84fda907-c90d-4c16-8815-97f4f363045b#
```
